### PR TITLE
Remove gdal dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -12,8 +12,6 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-gdal:
-- '3.2'
 jsoncpp:
 - 1.9.4
 openssl:
@@ -21,8 +19,6 @@ openssl:
 pin_run_as_build:
   curl:
     max_pin: x
-  gdal:
-    max_pin: x.x
   jsoncpp:
     max_pin: x.x.x
   openssl:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -10,8 +10,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
-gdal:
-- '3.2'
 jsoncpp:
 - 1.9.4
 macos_machine:
@@ -21,8 +19,6 @@ openssl:
 pin_run_as_build:
   curl:
     max_pin: x
-  gdal:
-    max_pin: x.x
   jsoncpp:
     max_pin: x.x.x
   openssl:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,8 +6,6 @@ curl:
 - '7'
 cxx_compiler:
 - vs2017
-gdal:
-- '3.2'
 jsoncpp:
 - 1.9.4
 openssl:
@@ -15,8 +13,6 @@ openssl:
 pin_run_as_build:
   curl:
     max_pin: x
-  gdal:
-    max_pin: x.x
   jsoncpp:
     max_pin: x.x.x
   openssl:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,12 @@ requirements:
     - cmake
   host:
     - pdal
-    - gdal
     - xz
     - curl
     - jsoncpp
     - openssl
   run:
     - pdal
-    - gdal
     - xz
     - curl
     - jsoncpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 9
+  number: 10
   skip: True  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
GDAL is not a direct dependency of Entwine.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
